### PR TITLE
Add Authorization to Vary header

### DIFF
--- a/src/ZfrOAuth2Module/Server/Module.php
+++ b/src/ZfrOAuth2Module/Server/Module.php
@@ -19,6 +19,8 @@
 namespace ZfrOAuth2Module\Server;
 
 use Zend\Console\Adapter\AdapterInterface;
+use Zend\EventManager\EventInterface;
+use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\ModuleManager\Feature\ConsoleBannerProviderInterface;
 use Zend\ModuleManager\Feature\ConsoleUsageProviderInterface;
@@ -30,11 +32,24 @@ use Zend\ModuleManager\Feature\DependencyIndicatorInterface;
  * @license MIT
  */
 class Module implements
+    BootstrapListenerInterface,
     ConfigProviderInterface,
     ConsoleBannerProviderInterface,
     ConsoleUsageProviderInterface,
     DependencyIndicatorInterface
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function onBootstrap(EventInterface $event)
+    {
+        /* @var \Zend\Mvc\Application $application */
+        $application  = $event->getTarget();
+        $eventManager = $application->getEventManager();
+
+        $eventManager->attach(new AuthorizationVaryListener());
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/ZfrOAuth2Module/Server/Mvc/AuthorizationVaryListener.php
+++ b/src/ZfrOAuth2Module/Server/Mvc/AuthorizationVaryListener.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrOAuth2Module\Server\Mvc;
+
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\EventManager\ListenerAggregateTrait;
+use Zend\Http\Request as HttpRequest;
+use Zend\Mvc\MvcEvent;
+
+/**
+ * This listener automatically adds the Authorization header to the Vary header if it exists. This
+ * is needed when you want to cache private resource
+ *
+ * @author  Michaël Gallego <mic.gallego@gmail.com>
+ * @licence MIT
+ */
+class AuthorizationVaryListener implements ListenerAggregateInterface
+{
+    use ListenerAggregateTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function attach(EventManagerInterface $events)
+    {
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_FINISH, [$this, 'alterVaryHeader']);
+    }
+
+    /**
+     * @internal
+     * @param  MvcEvent $event
+     * @return void
+     */
+    public function alterVaryHeader(MvcEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (!$request instanceof HttpRequest || !$request->getHeaders()->has('Authorization')) {
+            return;
+        }
+
+        /* @var \Zend\Http\Response $response */
+        $response = $event->getResponse();
+        $headers  = $response->getHeaders();
+
+        if ($headers->has('Vary')) {
+            $varyHeader = $headers->get('Vary');
+            $varyValue  = $varyHeader->getFieldValue() . ', Authorization';
+
+            $headers->removeHeader($varyHeader);
+            $headers->addHeaderLine('Vary', $varyValue);
+        } else {
+            $headers->addHeaderLine('Vary', 'Authorization');
+        }
+    }
+}

--- a/tests/ZfrOAuth2ModuleTest/Server/Mvc/AuthorizationVaryListenerTest.php
+++ b/tests/ZfrOAuth2ModuleTest/Server/Mvc/AuthorizationVaryListenerTest.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrOAuth2ModuleTest\Server\Mvc;
+
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+use Zend\Mvc\MvcEvent;
+use ZfrOAuth2Module\Server\Mvc\AuthorizationVaryListener;
+
+/**
+ * @author  Michaël Gallego <mic.gallego@gmail.com>
+ * @licence MIT
+ *
+ * @covers ZfrOAuth2Module\Server\Mvc\AuthorizationVaryListener
+ */
+class AuthorizationVaryListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoNotTouchResponseForRequestsWithoutAuthorization()
+    {
+        $mvcEvent = new MvcEvent();
+        $mvcEvent->setRequest(new HttpRequest());
+
+        $response = new HttpResponse();
+        $mvcEvent->setResponse($response);
+
+        $listener = new AuthorizationVaryListener();
+        $listener->alterVaryHeader($mvcEvent);
+
+        $this->assertFalse($response->getHeaders()->has('Vary'));
+    }
+
+    public function testAppendAuthorizationToVaryIfAlreadyExists()
+    {
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Authorization', 'abc');
+
+        $mvcEvent = new MvcEvent();
+        $mvcEvent->setRequest($request);
+
+        $response = new HttpResponse();
+        $response->getHeaders()->addHeaderLine('Vary', 'Origin');
+        $mvcEvent->setResponse($response);
+
+        $listener = new AuthorizationVaryListener();
+        $listener->alterVaryHeader($mvcEvent);
+
+        $this->assertTrue($response->getHeaders()->has('Vary'));
+        $this->assertEquals('Origin, Authorization', $response->getHeaders()->get('Vary')->getFieldValue());
+    }
+
+    public function testAddAuthorizationToVaryIfNotExists()
+    {
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Authorization', 'abc');
+
+        $mvcEvent = new MvcEvent();
+        $mvcEvent->setRequest($request);
+
+        $response = new HttpResponse();
+        $mvcEvent->setResponse($response);
+
+        $listener = new AuthorizationVaryListener();
+        $listener->alterVaryHeader($mvcEvent);
+
+        $this->assertTrue($response->getHeaders()->has('Vary'));
+        $this->assertEquals('Authorization', $response->getHeaders()->get('Vary')->getFieldValue());
+    }
+}


### PR DESCRIPTION
ping @Ocramius @mac_nibblet

When you use OAuth2 for your authorization, you likely hit your API with URLs like api.mywebsite.com/users/2, with a value inside the Authorization header.

However, this can be a problem for proxy server or for cacheable content in browser, because you likely need to perform authorization, and api.mywebist.com/users/2 may not return the same result for user A and B. To that extent, we need to add the Authorization value to the Vary header, to indicate proxy servers to use it to differentiate two resources.

This PR simply attaches a listener at the end of the request.
